### PR TITLE
feat: add animated hero section

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,14 +1,34 @@
-import { FC } from 'react';
-import logo from '../../assets/logo.svg';
+import { FC, useEffect, useState } from 'react';
 import Button from '../ui/Button';
 
-const Hero: FC = () => (
-  <section className="text-center py-16">
-    <img src={logo} alt="Techno Tech logo" className="mx-auto mb-8 w-32" />
-    <h2 className="mb-4 text-3xl font-semibold">Welcome to Techno Tech</h2>
-    <p className="mb-6 text-gray-600">Building modern web experiences.</p>
-    <Button>Get Started</Button>
-  </section>
-);
+const Hero: FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(true);
+  }, []);
+
+  return (
+    <section className="w-full min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-600 via-purple-600 to-fuchsia-600 text-white">
+      <div className="container mx-auto flex flex-col md:flex-row items-center gap-10 px-6 py-20">
+        <div className={`flex-1 text-center md:text-left transition-all duration-700 ${visible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-6'}`}>
+          <h1 className="text-4xl md:text-6xl font-bold mb-6">AI-Powered Solutions for Modern Businesses</h1>
+          <p className="mb-8 text-lg max-w-xl mx-auto md:mx-0">
+            We help small and medium businesses scale faster using automation, AI, and digital platforms tailored to their needs.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 justify-center md:justify-start">
+            <Button className="shadow-lg hover:shadow-xl">Request a Demo</Button>
+            <Button variant="secondary" className="shadow-lg hover:shadow-xl">Learn More</Button>
+          </div>
+        </div>
+        <div className={`flex-1 flex justify-center transition-all duration-700 ${visible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-6'}`}>
+          <div className="w-72 h-72 md:w-96 md:h-96 bg-white/10 rounded-2xl shadow-2xl flex items-center justify-center backdrop-blur-sm hover:scale-105 transition-transform">
+            <span className="text-white/70">AI Image Placeholder</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
 
 export default Hero;

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,9 +1,17 @@
-import { FC, PropsWithChildren } from 'react';
+import { ButtonHTMLAttributes, FC } from 'react';
 
-const Button: FC<PropsWithChildren> = ({ children }) => (
-  <button className="px-4 py-2 bg-blue-600 text-white rounded">
-    {children}
-  </button>
-);
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'secondary';
+}
+
+const Button: FC<ButtonProps> = ({ variant = 'default', className = '', ...props }) => {
+  const base = 'px-6 py-3 rounded-md font-medium transition-colors focus:outline-none';
+  const variants: Record<'default' | 'secondary', string> = {
+    default: 'bg-blue-600 text-white hover:bg-blue-700',
+    secondary: 'border border-white text-white hover:bg-white/10',
+  };
+
+  return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
+};
 
 export default Button;


### PR DESCRIPTION
## Summary
- introduce a full-screen gradient Hero section with animated text and placeholder graphic
- add primary and secondary call-to-action buttons with subtle depth effects
- extend Button component to support secondary variant styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891593d4db4832fb206c2b33c0bd7f4