### PR TITLE
feat: add CTA section component

### DIFF
--- a/src/components/sections/cta.tsx
+++ b/src/components/sections/cta.tsx
@@ -1,0 +1,43 @@
+import { FC, useEffect, useState } from 'react';
+
+const CTA: FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 100);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <section className="bg-gradient-to-r from-[#111] to-[#1a1a1a] py-20">
+      <div
+        className={`max-w-xl mx-auto px-4 text-center transition-all duration-700 ${
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+        }`}
+      >
+        <h3 className="mb-4 text-3xl font-semibold text-white">
+          Ready to level up your business?
+        </h3>
+        <p className="mb-8 text-gray-300">
+          Let's build something extraordinary together.
+        </p>
+        <div className="flex flex-col justify-center gap-4 sm:flex-row">
+          <a
+            href="#"
+            className="rounded-lg bg-indigo-600 px-6 py-3 text-lg font-medium text-white transition-transform hover:scale-105 hover:shadow-lg"
+          >
+            📞 Book a Free Consultation
+          </a>
+          <a
+            href="#"
+            className="rounded-lg border border-indigo-500 px-6 py-3 text-lg font-medium text-indigo-500 transition-colors hover:bg-indigo-500 hover:text-white"
+          >
+            📨 Send us a message
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CTA;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- add animated call-to-action section with consultation and message buttons
- allow importing SVG assets via new type declarations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68915a3a75e8832f918a374d1ca36c45