### PR TITLE
feat: add contact section

### DIFF
--- a/src/components/sections/contact.tsx
+++ b/src/components/sections/contact.tsx
@@ -1,0 +1,48 @@
+import { FC, FormEvent, useState } from 'react';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
+import Textarea from '../ui/Textarea';
+import Label from '../ui/Label';
+
+const Contact: FC = () => {
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <section className="py-16 flex justify-center">
+      <div className="w-full max-w-md bg-gray-50 p-6 rounded-lg shadow-md">
+        {submitted ? (
+          <p className="text-center text-green-600">Message sent successfully!</p>
+        ) : (
+          <>
+            <h3 className="mb-2 text-center text-2xl font-semibold">Get in Touch</h3>
+            <p className="mb-6 text-center text-gray-600">
+              We’d love to hear from you. Whether you’re curious about features, a free trial, or even press—we’re ready to answer any and all questions.
+            </p>
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" required placeholder="Full Name" />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" type="email" required placeholder="you@example.com" />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="message">Message</Label>
+                <Textarea id="message" required rows={4} placeholder="Your message" />
+              </div>
+              <Button type="submit" className="shadow-sm hover:shadow-md transition-shadow">Send Message</Button>
+            </form>
+          </>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default Contact;

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,14 @@
+import { FC, InputHTMLAttributes } from 'react';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+const Input: FC<InputProps> = ({ className = '', ...props }) => {
+  return (
+    <input
+      className={`w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none transition ${className}`}
+      {...props}
+    />
+  );
+};
+
+export default Input;

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -1,0 +1,9 @@
+import { FC, LabelHTMLAttributes } from 'react';
+
+interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label: FC<LabelProps> = ({ className = '', ...props }) => (
+  <label className={`text-sm font-medium text-gray-700 ${className}`} {...props} />
+);
+
+export default Label;

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,14 @@
+import { FC, TextareaHTMLAttributes } from 'react';
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea: FC<TextareaProps> = ({ className = '', ...props }) => {
+  return (
+    <textarea
+      className={`w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none transition ${className}`}
+      {...props}
+    />
+  );
+};
+
+export default Textarea;


### PR DESCRIPTION
## Summary
- add contact section with form and mock submission state
- create simple Input, Textarea, and Label components to support form

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68915ab9eed0832fbb5e731f3bf78280