### PR TITLE
feat: add responsive footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import Header from './components/layout/Header';
-import Footer from './components/layout/Footer';
+import Footer from './components/layout/footer';
 import Hero from './components/sections/Hero';
 
 function App() {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,9 +1,0 @@
-import { FC } from 'react';
-
-const Footer: FC = () => (
-  <footer className="py-4 text-center text-sm text-gray-500">
-    © {new Date().getFullYear()} Techno Tech
-  </footer>
-);
-
-export default Footer;

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react';
+import logo from '../../assets/logo.svg';
+
+const links = [
+  { label: 'Home', href: '#' },
+  { label: 'Services', href: '#' },
+  { label: 'About', href: '#' },
+  { label: 'Contact', href: '#' },
+];
+
+const Footer: FC = () => (
+  <footer className="mt-24 bg-[#0f0f0f] text-gray-400 font-sans">
+    <div className="mx-auto max-w-7xl px-6 py-12">
+      <div className="flex flex-col items-center justify-between gap-8 md:flex-row">
+        <div className="flex items-center gap-2">
+          <img src={logo} alt="Techno Tech logo" className="h-8" />
+          <span className="font-semibold text-white">Techno Tech</span>
+        </div>
+        <ul className="flex flex-col items-center gap-4 md:flex-row">
+          {links.map((link) => (
+            <li key={link.label}>
+              <a href={link.href} className="transition-colors hover:text-white">
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <p className="mt-8 text-center text-sm text-gray-500">
+        © 2025 Techno Tech Inc. All rights reserved.
+      </p>
+    </div>
+  </footer>
+);
+
+export default Footer;
+


### PR DESCRIPTION
## Summary
- add responsive footer with logo, quick links, and copyright
- switch app to use new footer component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689162cc9010832faf348981382c4527