### PR TITLE
feat: add services section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,27 @@
-import Index from './pages/Index';
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
+import Hero from '@/components/sections/hero';
+import About from '@/components/sections/About';
+import ServicesSection from '@/components/sections/ServicesSection';
+import CTA from '@/components/sections/cta';
+import Contact from '@/components/sections/contact';
 
 function App() {
-  return <Index />;
+  return (
+    <>
+      <div className="max-w-7xl mx-auto px-4">
+        <Header />
+      </div>
+      <Hero />
+      <About />
+      <ServicesSection />
+      <CTA />
+      <Contact />
+      <div className="max-w-7xl mx-auto px-4">
+        <Footer />
+      </div>
+    </>
+  );
 }
 
 export default App;
-

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -1,0 +1,118 @@
+import { FC } from 'react';
+import { motion } from 'framer-motion';
+
+const services = [
+  {
+    icon: CpuIcon,
+    title: 'AI Integration',
+    description: 'Empower your business with AI-powered decisions.',
+  },
+  {
+    icon: WorkflowIcon,
+    title: 'Business Automation',
+    description: 'Automate repetitive tasks and boost productivity.',
+  },
+  {
+    icon: GlobeIcon,
+    title: 'Smart Web Apps',
+    description: 'Custom web platforms tailored to your needs.',
+  },
+];
+
+const ServicesSection: FC = () => {
+  return (
+    <section className="py-16 bg-gray-50">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl font-semibold text-center mb-4">Our Services</h2>
+        <p className="text-gray-600 text-center mb-12">
+          Solutions designed to keep your business ahead.
+        </p>
+        <div className="grid gap-8 md:grid-cols-3">
+          {services.map(({ icon: Icon, title, description }, index) => (
+            <motion.div
+              key={title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.8 }}
+              transition={{ duration: 0.5, delay: index * 0.2 }}
+              className="rounded-lg bg-white p-6 shadow-md hover:shadow-lg transition-shadow flex flex-col items-center text-center"
+            >
+              <Icon className="mb-4 h-12 w-12 text-[#6d071a]" />
+              <h3 className="mb-2 text-xl font-medium">{title}</h3>
+              <p className="text-gray-600">{description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ServicesSection;
+
+// Inline SVG icons mimicking Lucide style
+function CpuIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <rect x="4" y="4" width="16" height="16" rx="2" />
+      <rect x="9" y="9" width="6" height="6" />
+      <line x1="9" y1="1" x2="9" y2="4" />
+      <line x1="15" y1="1" x2="15" y2="4" />
+      <line x1="9" y1="20" x2="9" y2="23" />
+      <line x1="15" y1="20" x2="15" y2="23" />
+      <line x1="1" y1="9" x2="4" y2="9" />
+      <line x1="1" y1="15" x2="4" y2="15" />
+      <line x1="20" y1="9" x2="23" y2="9" />
+      <line x1="20" y1="15" x2="23" y2="15" />
+    </svg>
+  );
+}
+
+function WorkflowIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <rect x="3" y="3" width="6" height="6" rx="1" />
+      <rect x="15" y="3" width="6" height="6" rx="1" />
+      <rect x="15" y="15" width="6" height="6" rx="1" />
+      <path d="M9 6h6" />
+      <path d="M18 9v6" />
+    </svg>
+  );
+}
+
+function GlobeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="2" y1="12" x2="22" y2="12" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add animated ServicesSection with three service cards and inline SVG icons
- integrate ServicesSection into main App layout under Hero/About

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689167ca8484832f9cf97c8bf2341b00