### PR TITLE
feat: add CTA section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,17 @@
 import Index from './pages/Index';
+import CTASection from '@/components/sections/CTASection';
+import Footer from '@/components/layout/Footer';
 
 function App() {
-  return <Index />;
+  return (
+    <>
+      <Index />
+      <CTASection />
+      <div className="max-w-7xl mx-auto px-4">
+        <Footer />
+      </div>
+    </>
+  );
 }
 
 export default App;

--- a/src/components/sections/CTASection.tsx
+++ b/src/components/sections/CTASection.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react';
+import { motion } from 'framer-motion';
+
+const CTASection: FC = () => {
+  return (
+    <section className="w-full bg-gradient-to-br from-gray-900 via-gray-800 to-black py-24">
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+        className="mx-auto max-w-3xl px-6 text-center"
+      >
+        <h2 className="mb-4 text-3xl font-bold text-white">
+          Ready to future-proof your business?
+        </h2>
+        <p className="mb-8 text-lg text-gray-300">
+          Let’s build smart systems together. Contact us today and start your transformation.
+        </p>
+        <a
+          href="mailto:technoartsy@gmail.com"
+          className="inline-block rounded-md bg-indigo-600 px-8 py-4 text-lg font-semibold text-white transition-colors hover:bg-indigo-500"
+        >
+          Get in Touch
+        </a>
+      </motion.div>
+    </section>
+  );
+};
+
+export default CTASection;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,9 +1,7 @@
 import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import Hero from '@/components/sections/hero';
 import About from '@/components/sections/About';
 import Services from '@/components/sections/Services';
-import CTA from '@/components/sections/cta';
 import Contact from '@/components/sections/contact';
 
 function Index() {
@@ -15,11 +13,7 @@ function Index() {
       <Hero />
       <About />
       <Services />
-      <CTA />
       <Contact />
-      <div className="max-w-7xl mx-auto px-4">
-        <Footer />
-      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add animated call-to-action section with mailto link
- render CTA before footer on landing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68916840ad18832fb81f6e51cca096f9