### PR TITLE
feat: polish landing visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Techno Tech</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,8 @@ import Footer from '@/components/layout/Footer';
 import Hero from '@/components/sections/hero';
 import AboutSection from '@/components/sections/AboutSection';
 import ServicesSection from '@/components/sections/ServicesSection';
-import CTA from '@/components/sections/cta';
 import Contact from '@/components/sections/contact';
- codex/add-calltoaction-component-section
 import CallToAction from '@/components/sections/CallToAction';
-
- main
 
 function App() {
   return (
@@ -19,11 +15,8 @@ function App() {
       <Hero />
       <AboutSection />
       <ServicesSection />
-      <CTA />
-      <Contact />
- codex/add-calltoaction-component-section
       <CallToAction />
-main
+      <Contact />
       <div className="max-w-7xl mx-auto px-4">
         <Footer />
       </div>

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -1,123 +1,14 @@
 import { FC } from 'react';
 import { motion } from 'framer-motion';
-29vrtp-codex/add-servicessection-component
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from '@/components/ui/card';
-
-v1kezo-codex/add-servicessection-component
-main
-
 interface Service {
-  title: string;
-  description: string;
-  icon: JSX.Element;
-}
-
-const services: Service[] = [
-  {
-    title: 'Smart Web Platforms',
-    description:
-      'We design and build tailored web apps that automate business tasks and boost efficiency.',
-    icon: (
-      <svg
-        className="h-10 w-10 text-[#6d071a]"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <line x1="2" y1="12" x2="22" y2="12" />
-        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Business Automation',
-    description:
-      'From invoices to inventory, we build AI-powered tools that save time and reduce errors.',
-    icon: (
-      <svg
-        className="h-10 w-10 text-[#6d071a]"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <rect x="8" y="3" width="8" height="4" rx="1" />
-        <rect x="8" y="17" width="8" height="4" rx="1" />
-        <path d="M12 7v10" />
-        <path d="M5 11h14" />
-      </svg>
-    ),
-  },
-  {
-    title: 'AI Integration & Consulting',
-    description:
-      'Unlock the power of artificial intelligence in your business with our custom solutions.',
-    icon: (
-      <svg
-        className="h-10 w-10 text-[#6d071a]"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M12 3a5 5 0 0 0-5 5v1a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3v1a5 5 0 0 0 10 0v-1a3 3 0 0 0 3-3v-2a3 3 0 0 0-3-3V8a5 5 0 0 0-5-5Z" />
-      </svg>
-    ),
-  },
-];
-
-const ServicesSection: FC = () => (
-  <section id="services" className="py-16 bg-white">
-    <div className="container mx-auto px-4">
-      <h2 className="mb-12 text-center text-3xl font-semibold">What We Do</h2>
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
-        {services.map((service, index) => (
-          <motion.div
-            key={service.title}
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: index * 0.1 }}
-          >
- 29vrtp-codex/add-servicessection-component
-            <Card className="h-full">
-              <CardHeader className="space-y-4 text-center">
-                {service.icon}
-                <CardTitle>{service.title}</CardTitle>
-                <CardDescription>{service.description}</CardDescription>
-              </CardHeader>
-            </Card>
-
-            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-md bg-gray-100 dark:bg-gray-700">
-              {service.icon}
-            </div>
-            <h3 className="mb-2 text-xl font-medium">{service.title}</h3>
-            <p className="text-gray-600 dark:text-gray-300">{service.description}</p>
-            
- codex/create-servicessection-component
- main
-interface ServiceItem {
   Icon: (props: { className?: string }) => JSX.Element;
   title: string;
   description: string;
 }
 
-const services: ServiceItem[] = [
+const services: Service[] = [
   {
     Icon: GlobeIcon,
     title: 'Smart Web Platforms',
@@ -128,7 +19,7 @@ const services: ServiceItem[] = [
     Icon: WorkflowIcon,
     title: 'Business Automation',
     description:
-      'From invoices to inventory, we build AI-powered tools that save time and reduce errors.',
+      'From invoices to inventory, we build tools that save time and reduce errors.',
   },
   {
     Icon: CpuIcon,
@@ -139,35 +30,28 @@ const services: ServiceItem[] = [
 ];
 
 const ServicesSection: FC = () => (
-  <section className="py-16 bg-gray-50">
+  <section
+    id="services"
+    className="py-20 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800"
+  >
     <div className="container mx-auto px-4">
-      <h2 className="mb-12 text-center text-3xl font-semibold">What We Do</h2>
+      <h2 className="mb-12 text-center text-3xl font-semibold">Our Services</h2>
       <div className="grid gap-8 md:grid-cols-3">
         {services.map(({ Icon, title, description }, index) => (
           <motion.div
             key={title}
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: index * 0.1 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: index * 0.2 }}
           >
-            v1kezo-codex/add-servicessection-component
             <Card className="h-full text-center">
-              <CardHeader>
-                <Icon className="mx-auto mb-4 h-12 w-12 text-[#6d071a]" />
-                <CardTitle className="mb-2 text-xl">{title}</CardTitle>
-                <CardDescription className="text-gray-600">
-                  {description}
-                </CardDescription>
+              <CardHeader className="space-y-4">
+                <Icon className="mx-auto h-12 w-12 text-[#6d071a]" />
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
               </CardHeader>
             </Card>
-            
-            <Icon className="mx-auto mb-4 h-12 w-12 text-[#6d071a]" />
-            <h3 className="mb-2 text-xl font-medium">{title}</h3>
-            <p className="text-gray-600">{description}</p>
-main
-main
- main
           </motion.div>
         ))}
       </div>
@@ -176,18 +60,11 @@ main
 );
 
 export default ServicesSection;
-29vrtp-codex/add-servicessection-component
 
-
- v1kezo-codex/add-servicessection-component
-// Inline Lucide-style icons
 function GlobeIcon({ className }: { className?: string }) {
-m666wy-codex/create-servicessection-component
-
-function BrainCogIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
-      {...props}
+      className={className}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -195,60 +72,9 @@ function BrainCogIcon(props: React.SVGProps<SVGSVGElement>) {
       strokeLinecap="round"
       strokeLinejoin="round"
     >
-      <path d="M9 3a2 2 0 0 0-2 2v1a2 2 0 0 0-2 2v2a2 2 0 0 0 1 1.73V14a2 2 0 0 0 2 2h1" />
-      <path d="M15 3a2 2 0 0 1 2 2v1a2 2 0 0 1 2 2v1" />
-      <path d="M15 21v-2a2 2 0 0 0-2-2h-2" />
-      <path d="M22 17h-1.26a4 4 0 0 1-.74 1.26l.89.89-1.42 1.42-.89-.89A4 4 0 0 1 17 22v-1.26a4 4 0 0 1-1.26-.74l-.89.89-1.42-1.42.89-.89A4 4 0 0 1 13 17h-1" />
-      <path d="M16 16h.01" />
-
-const ServicesSection: FC = () => {
-  return (
-    <section className="py-16 bg-gray-50">
-      <div className="container mx-auto px-4">
-        <h2 className="text-3xl font-semibold text-center mb-4">Our Services</h2>
-        <p className="text-gray-600 text-center mb-12">
-          Solutions designed to keep your business ahead.
-        </p>
-        <div className="grid gap-8 md:grid-cols-3">
-          {services.map(({ icon: Icon, title, description }, index) => (
-            <motion.div
-              key={title}
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.8 }}
-              transition={{ duration: 0.5, delay: index * 0.2 }}
-              className="rounded-lg bg-white p-6 shadow-md hover:shadow-lg transition-shadow flex flex-col items-center text-center"
-            >
-              <Icon className="mb-4 h-12 w-12 text-[#6d071a]" />
-              <h3 className="mb-2 text-xl font-medium">{title}</h3>
-              <p className="text-gray-600">{description}</p>
-            </motion.div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-};
-
-export default ServicesSection;
-
-// Inline SVG icons mimicking Lucide style
-function CpuIcon({ className }: { className?: string }) {
-main
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
       <circle cx="12" cy="12" r="10" />
       <line x1="2" y1="12" x2="22" y2="12" />
-      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10" />
     </svg>
   );
 }
@@ -256,20 +82,18 @@ main
 function WorkflowIcon({ className }: { className?: string }) {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
+      className={className}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
-      className={className}
     >
-      <rect x="3" y="3" width="6" height="6" rx="1" />
-      <rect x="15" y="3" width="6" height="6" rx="1" />
-      <rect x="15" y="15" width="6" height="6" rx="1" />
-      <path d="M9 6h6" />
-      <path d="M18 9v6" />
+      <rect x="8" y="3" width="8" height="4" rx="1" />
+      <rect x="8" y="17" width="8" height="4" rx="1" />
+      <path d="M12 7v10" />
+      <path d="M5 11h14" />
     </svg>
   );
 }
@@ -277,32 +101,24 @@ function WorkflowIcon({ className }: { className?: string }) {
 function CpuIcon({ className }: { className?: string }) {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
+      className={className}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
-      className={className}
     >
       <rect x="4" y="4" width="16" height="16" rx="2" />
       <rect x="9" y="9" width="6" height="6" />
-      <line x1="9" y1="1" x2="9" y2="4" />
-      <line x1="15" y1="1" x2="15" y2="4" />
-      <line x1="9" y1="20" x2="9" y2="23" />
-      <line x1="15" y1="20" x2="15" y2="23" />
-      <line x1="1" y1="9" x2="4" y2="9" />
-      <line x1="1" y1="15" x2="4" y2="15" />
-      <line x1="20" y1="9" x2="23" y2="9" />
-      <line x1="20" y1="15" x2="23" y2="15" />
+      <path d="M9 1v2" />
+      <path d="M15 1v2" />
+      <path d="M1 9h2" />
+      <path d="M1 15h2" />
+      <path d="M21 9h2" />
+      <path d="M21 15h2" />
+      <path d="M9 21v2" />
+      <path d="M15 21v2" />
     </svg>
   );
 }
-
-v1kezo-codex/add-servicessection-component
-
-main
-      main
-main
- main

--- a/src/components/sections/contact.tsx
+++ b/src/components/sections/contact.tsx
@@ -1,4 +1,5 @@
 import { FC, FormEvent, useState } from 'react';
+import { motion } from 'framer-motion';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Textarea from '../ui/Textarea';
@@ -13,36 +14,107 @@ const Contact: FC = () => {
   };
 
   return (
-    <section id="contact" className="py-16 flex justify-center">
-      <div className="w-full max-w-md bg-gray-50 p-6 rounded-lg shadow-md">
+    <motion.section
+      id="contact"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      viewport={{ once: true }}
+      className="py-20 bg-gradient-to-r from-white to-gray-50 dark:from-gray-900 dark:to-gray-800"
+    >
+      <div className="container mx-auto max-w-3xl px-4">
+        <h3 className="mb-6 text-center text-3xl font-semibold">Get in Touch</h3>
+        <div className="mb-8 space-y-4 text-gray-700 dark:text-gray-300">
+          <div className="flex items-center gap-3">
+            <MailIcon className="h-5 w-5 text-[#6d071a]" />
+            <span>hello@technotech.com</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <PhoneIcon className="h-5 w-5 text-[#6d071a]" />
+            <span>+123 456 7890</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <MapPinIcon className="h-5 w-5 text-[#6d071a]" />
+            <span>123 Tech Street, Innovation City</span>
+          </div>
+        </div>
         {submitted ? (
           <p className="text-center text-green-600">Message sent successfully!</p>
         ) : (
-          <>
-            <h3 className="mb-2 text-center text-2xl font-semibold">Get in Touch</h3>
-            <p className="mb-6 text-center text-gray-600">
-              We’d love to hear from you. Whether you’re curious about features, a free trial, or even press—we’re ready to answer any and all questions.
-            </p>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="name">Name</Label>
-                <Input id="name" required placeholder="Full Name" />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="email">Email</Label>
-                <Input id="email" type="email" required placeholder="you@example.com" />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="message">Message</Label>
-                <Textarea id="message" required rows={4} placeholder="Your message" />
-              </div>
-              <Button type="submit" className="shadow-sm hover:shadow-md transition-shadow">Send Message</Button>
-            </form>
-          </>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="name">Name</Label>
+              <Input id="name" required placeholder="Full Name" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" required placeholder="you@example.com" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="message">Message</Label>
+              <Textarea id="message" required rows={4} placeholder="Your message" />
+            </div>
+            <Button
+              type="submit"
+              className="shadow-md transition-shadow hover:shadow-lg"
+            >
+              Send Message
+            </Button>
+          </form>
         )}
       </div>
-    </section>
+    </motion.section>
   );
 };
 
 export default Contact;
+
+function MailIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <polyline points="3 7 12 13 21 7" />
+    </svg>
+  );
+}
+
+function PhoneIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7 2 2 0 0 1 1.72 2z" />
+    </svg>
+  );
+}
+
+function MapPinIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 1 1 18 0z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -5,13 +5,17 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const Button: FC<ButtonProps> = ({ variant = 'default', className = '', ...props }) => {
-  const base = 'px-6 py-3 rounded-md font-medium transition-colors focus:outline-none';
+  const base =
+    'px-6 py-3 rounded-md font-medium focus:outline-none transition-colors duration-300 shadow-md hover:shadow-lg';
   const variants: Record<'default' | 'secondary', string> = {
-    default: 'bg-blue-600 text-white hover:bg-blue-700',
-    secondary: 'border border-white text-white hover:bg-white/10',
+    default: 'bg-[#6d071a] text-white hover:bg-[#540515]',
+    secondary:
+      'border border-[#6d071a] text-[#6d071a] hover:bg-[#6d071a] hover:text-white',
   };
 
-  return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
+  return (
+    <button className={`${base} ${variants[variant]} ${className}`} {...props} />
+  );
 };
 
 export default Button;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,4 +1,3 @@
- 29vrtp-codex/add-servicessection-component
 import * as React from 'react';
 
 function cn(...classes: (string | undefined)[]) {
@@ -7,78 +6,41 @@ function cn(...classes: (string | undefined)[]) {
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
 
-const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('rounded-xl border bg-white text-gray-900 shadow', className)} {...props} />
+const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className = '', ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-xl border bg-white text-gray-900 shadow transition-shadow hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100',
+      className,
+    )}
+    {...props}
+  />
 ));
 Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+  ({ className = '', ...props }, ref) => (
     <div ref={ref} className={cn('p-6', className)} {...props} />
   )
 );
 CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn('text-xl font-semibold leading-none tracking-tight', className)} {...props} />
+  ({ className = '', ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('text-xl font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
   )
 );
 CardTitle.displayName = 'CardTitle';
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn('text-sm text-gray-600', className)} {...props} />
+  ({ className = '', ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-gray-600 dark:text-gray-300', className)} {...props} />
   )
 );
 CardDescription.displayName = 'CardDescription';
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
-  )
-);
-CardContent.displayName = 'CardContent';
-
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
-  )
-);
-CardFooter.displayName = 'CardFooter';
-
-export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };
-=======
-import { FC, HTMLAttributes } from 'react';
-
-export const Card: FC<HTMLAttributes<HTMLDivElement>> = ({
-  className = '',
-  ...props
-}) => (
-  <div className={`rounded-lg border bg-white shadow-md ${className}`} {...props} />
-);
-
-export const CardHeader: FC<HTMLAttributes<HTMLDivElement>> = ({
-  className = '',
-  ...props
-}) => <div className={`p-6 ${className}`} {...props} />;
-
-export const CardTitle: FC<HTMLAttributes<HTMLHeadingElement>> = ({
-  className = '',
-  ...props
-}) => (
-  <h3
-    className={`text-lg font-semibold leading-none tracking-tight ${className}`}
-    {...props}
-  />
-);
-
-export const CardDescription: FC<HTMLAttributes<HTMLParagraphElement>> = ({
-  className = '',
-  ...props
-}) => (
-  <p className={`text-sm text-gray-600 ${className}`} {...props} />
-);
-
-export default Card;
- main
+export { Card, CardHeader, CardTitle, CardDescription };

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,9 +1,14 @@
 import type { Config } from 'tailwindcss';
 
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- load Inter globally and enable dark mode transitions
- add hover animations and gradients for cards, buttons, and sections
- redesign services and contact sections with icons and fade-in effects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925f10c610832f9aa0ce7a7784d2ec