### PR TITLE
feat: add contact form validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "framer-motion": "^10.16.4"
+    "framer-motion": "^10.16.4",
+    "@hookform/resolvers": "^3.3.4",
+    "react-hook-form": "^7.49.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/components/sections/contact.tsx
+++ b/src/components/sections/contact.tsx
@@ -1,15 +1,53 @@
-import { FC, FormEvent, useState } from 'react';
+import { FC, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Textarea from '../ui/Textarea';
-import Label from '../ui/Label';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '../ui/form';
 
 const Contact: FC = () => {
   const [submitted, setSubmitted] = useState(false);
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
+  const formSchema = z.object({
+    name: z.string().min(3, { message: 'Name must be at least 3 characters.' }),
+    email: z.string().email({ message: 'Please enter a valid email address.' }),
+    phone: z
+      .string()
+      .optional()
+      .refine(
+        (val) => !val || /^[+\d][\d\s()-]{7,}$/i.test(val),
+        { message: 'Please enter a valid phone number.' }
+      ),
+    message: z
+      .string()
+      .min(10, { message: 'Message must be at least 10 characters.' }),
+  });
+
+  type ContactFormData = z.infer<typeof formSchema>;
+
+  const form = useForm<ContactFormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      email: '',
+      phone: '',
+      message: '',
+    },
+  });
+
+  const onSubmit = () => {
     setSubmitted(true);
+    form.reset();
   };
 
   return (
@@ -19,25 +57,73 @@ const Contact: FC = () => {
           <p className="text-center text-green-600">Message sent successfully!</p>
         ) : (
           <>
-            <h3 className="mb-2 text-center text-2xl font-semibold text-gray-900 dark:text-white">Get in Touch</h3>
+            <h3 className="mb-2 text-center text-2xl font-semibold text-gray-900 dark:text-white">
+              Get in Touch
+            </h3>
             <p className="mb-6 text-center text-gray-600 dark:text-gray-300">
               We’d love to hear from you. Whether you’re curious about features, a free trial, or even press—we’re ready to answer any and all questions.
             </p>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="name">Name</Label>
-                <Input id="name" required placeholder="Full Name" />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="email">Email</Label>
-                <Input id="email" type="email" required placeholder="you@example.com" />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="message">Message</Label>
-                <Textarea id="message" required rows={4} placeholder="Your message" />
-              </div>
-              <Button type="submit" className="shadow-sm transition-shadow hover:shadow-md">Send Message</Button>
-            </form>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Name</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Full Name" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+                        <FormControl>
+                          <Input type="email" placeholder="you@example.com" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Phone</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Phone (optional)" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="message"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Message</FormLabel>
+                      <FormControl>
+                        <Textarea rows={4} placeholder="Your message" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit" className="shadow-sm transition-shadow hover:shadow-md">
+                  Send Message ✉️
+                </Button>
+              </form>
+            </Form>
           </>
         )}
       </div>

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,46 @@
+import { Controller, FieldPath, FieldValues, FormProvider, UseFormReturn } from 'react-hook-form';
+import { forwardRef, HTMLAttributes, LabelHTMLAttributes } from 'react';
+
+export const Form = FormProvider;
+
+export function FormField<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>(props: {
+  control: UseFormReturn<TFieldValues>['control'];
+  name: TName;
+  render: (data: { field: any }) => JSX.Element;
+}) {
+  return <Controller {...props} />;
+}
+
+export const FormItem = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function FormItem(
+  { className = '', ...props },
+  ref,
+) {
+  return <div ref={ref} className={`space-y-2 ${className}`} {...props} />;
+});
+
+export const FormLabel = forwardRef<HTMLLabelElement, LabelHTMLAttributes<HTMLLabelElement>>(function FormLabel(
+  { className = '', ...props },
+  ref,
+) {
+  return <label ref={ref} className={`text-sm font-medium text-gray-700 dark:text-gray-300 ${className}`} {...props} />;
+});
+
+export const FormControl = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function FormControl(
+  { className = '', ...props },
+  ref,
+) {
+  return <div ref={ref} className={className} {...props} />;
+});
+
+export const FormMessage = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(function FormMessage(
+  { className = '', children, ...props },
+  ref,
+) {
+  return (
+    <p ref={ref} className={`text-sm text-red-600 ${className}`} {...props}>
+      {children}
+    </p>
+  );
+});
+
+export type { UseFormReturn };


### PR DESCRIPTION
## Summary
- add contact form with react-hook-form + zod validation
- create shadcn-style form primitives
- include form dependencies

## Testing
- `npm run build` *(fails: src/components/sections/ServicesSection.tsx(1,37): error TS1109: Expression expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68926e0face0832fa6257aa21a8755a9