### PR TITLE
fix: safeguard DOM access before binding

### DIFF
--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -1,10 +1,16 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import Button from '../ui/Button';
 
 const CallToAction: FC = () => {
+  const contactSection = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    contactSection.current = document.getElementById('contact');
+  }, []);
+
   const handleClick = () => {
-    document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' });
+    contactSection.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   return (

--- a/src/components/sections/cta.tsx
+++ b/src/components/sections/cta.tsx
@@ -1,10 +1,16 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import Button from '../ui/Button';
 
 const CTA: FC = () => {
+  const contactSection = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    contactSection.current = document.getElementById('contact');
+  }, []);
+
   const handleClick = () => {
-    document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' });
+    contactSection.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,11 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}


### PR DESCRIPTION
## Summary
- guard root element access before creating React root
- ensure call-to-action sections query DOM only after mount

## Testing
- `npm run build`
- `npm run dev` *(no errors, server started)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892791d0328832fbb25935493a15095