### PR TITLE
feat: redesign services section

### DIFF
--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -11,8 +11,6 @@ import {
   Workflow,
   Bot,
   Globe,
-  BarChart3,
-  Smartphone,
   LucideIcon,
 } from 'lucide-react';
 
@@ -38,16 +36,6 @@ const services: Service[] = [
     title: 'Web Platforms & Dashboards',
     description: 'Creating modern, fast and responsive platforms with admin panels.',
   },
-  {
-    icon: BarChart3,
-    title: 'Data Visualization & Reporting',
-    description: 'Interactive dashboards and insights powered by real-time data.',
-  },
-  {
-    icon: Smartphone,
-    title: 'Mobile-ready Interfaces',
-    description: 'UI/UX optimized for all screen sizes.',
-  },
 ];
 
 const ServicesSection: FC = () => (
@@ -69,10 +57,11 @@ const ServicesSection: FC = () => (
             key={service.title}
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
+            whileHover={{ y: -5 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: index * 0.1 }}
           >
-            <Card className="h-full dark:bg-gray-800">
+            <Card className="h-full bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl dark:bg-gray-800">
               <CardHeader className="space-y-4 text-center">
                 <Icon className="mx-auto h-10 w-10 text-[#6d071a]" />
                 <CardTitle className="text-gray-900 dark:text-white">


### PR DESCRIPTION
## Summary
- refresh ServicesSection with three concise service cards and modern motion effects
- apply 5D styling using soft shadows, rounded corners and hover animations

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927c02af88832f91b25845fc1b50ed