### PR TITLE
feat: add scroll animations to main sections

### DIFF
--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,37 +1,62 @@
 import { FC } from 'react';
+import { motion } from 'framer-motion';
 
 const About: FC = () => (
-  <section className="py-16 bg-white dark:bg-gray-900">
+  <motion.section
+    className="py-16 bg-white dark:bg-gray-900"
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.5 }}
+  >
     <div className="container mx-auto px-4">
       <h2 className="mb-4 text-center text-3xl font-semibold text-gray-900 dark:text-white">Who We Are</h2>
       <p className="mb-12 text-center text-gray-600 dark:text-gray-300">
         Techno Tech is a Canadian-based software agency helping businesses integrate AI, automation, and smart systems.
       </p>
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
-        <div className="rounded-lg bg-white dark:bg-gray-800 p-6 text-center shadow-md">
+        <motion.div
+          className="rounded-lg bg-white dark:bg-gray-800 p-6 text-center shadow-md"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
           <div className="mb-4 text-4xl">🧠</div>
           <h3 className="mb-2 text-xl font-medium text-gray-900 dark:text-white">AI Integration</h3>
           <p className="text-gray-600 dark:text-gray-300">
             Custom tools that help businesses leverage AI to simplify their workflow.
           </p>
-        </div>
-        <div className="rounded-lg bg-white dark:bg-gray-800 p-6 text-center shadow-md">
+        </motion.div>
+        <motion.div
+          className="rounded-lg bg-white dark:bg-gray-800 p-6 text-center shadow-md"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+        >
           <div className="mb-4 text-4xl">⚙️</div>
           <h3 className="mb-2 text-xl font-medium text-gray-900 dark:text-white">Automation Systems</h3>
           <p className="text-gray-600 dark:text-gray-300">
             We build automation pipelines tailored for operational efficiency.
           </p>
-        </div>
-        <div className="rounded-lg bg-white dark:bg-gray-800 p-6 text-center shadow-md">
+        </motion.div>
+        <motion.div
+          className="rounded-lg bg-white dark:bg-gray-800 p-6 text-center shadow-md"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+        >
           <div className="mb-4 text-4xl">🛠️</div>
           <h3 className="mb-2 text-xl font-medium text-gray-900 dark:text-white">Tailored Web Platforms</h3>
           <p className="text-gray-600 dark:text-gray-300">
             From websites to business dashboards, we create intuitive digital solutions.
           </p>
-        </div>
+        </motion.div>
       </div>
     </div>
-  </section>
+  </motion.section>
 );
 
 export default About;

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -38,7 +38,14 @@ const services: Service[] = [
 ];
 
 const ServicesSection: FC = () => (
-  <section id="services" className="py-16 bg-gray-50 dark:bg-gray-900">
+  <motion.section
+    id="services"
+    className="py-16 bg-gray-50 dark:bg-gray-900"
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.5 }}
+  >
     <div className="mx-auto mb-12 max-w-5xl px-4 text-center">
       <h2 className="mb-4 text-3xl font-semibold text-gray-900 dark:text-white">
         What We Do
@@ -75,7 +82,7 @@ const ServicesSection: FC = () => (
         );
       })}
     </div>
-  </section>
+  </motion.section>
 );
 
 export default ServicesSection;

--- a/src/components/sections/contact.tsx
+++ b/src/components/sections/contact.tsx
@@ -2,6 +2,7 @@ import { FC, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { motion } from 'framer-motion';
 
 import Button from '../ui/Button';
 import Input from '../ui/Input';
@@ -51,7 +52,14 @@ const Contact: FC = () => {
   };
 
   return (
-    <section id="contact" className="flex justify-center py-16 bg-white dark:bg-gray-900">
+    <motion.section
+      id="contact"
+      className="flex justify-center py-16 bg-white dark:bg-gray-900"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5 }}
+    >
       <div className="w-full max-w-md rounded-lg bg-gray-50 p-6 shadow-md dark:bg-gray-800">
         {submitted ? (
           <p className="text-center text-green-600">Message sent successfully!</p>
@@ -125,7 +133,7 @@ const Contact: FC = () => {
           </>
         )}
       </div>
-    </section>
+    </motion.section>
   );
 };
 

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -24,7 +24,8 @@ const Hero: FC = () => {
           <motion.h1
             className="text-4xl font-extrabold leading-tight sm:text-5xl md:text-6xl"
             initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
             transition={{ duration: 0.8 }}
           >
             Revolutionize Your Business
@@ -34,14 +35,16 @@ const Hero: FC = () => {
           <motion.p
             className="text-lg font-medium text-gray-200 md:text-xl"
             initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
             transition={{ delay: 0.2, duration: 0.8 }}
           >
             Techno Tech helps businesses automate, innovate, and grow using smart AI tools, dashboards, and custom web platforms.
           </motion.p>
           <motion.div
             initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
             transition={{ delay: 0.4, duration: 0.8 }}
           >
             <MotionButton
@@ -55,7 +58,8 @@ const Hero: FC = () => {
         </div>
         <motion.div
           initial={{ opacity: 0, x: 80 }}
-          animate={{ opacity: 1, x: 0 }}
+          whileInView={{ opacity: 1, x: 0 }}
+          viewport={{ once: true }}
           transition={{ delay: 0.6, duration: 0.8 }}
           className="relative"
         >


### PR DESCRIPTION
## Summary
- animate Hero text, button, and image on scroll with framer-motion
- fade in About, Services, and Contact sections as they enter the viewport

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927d9f83cc832fb47b6dbddec97c1f