### PR TITLE
Add portfolio section, testimonials revamp, and final footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Footer from '@/components/layout/Footer';
 import Hero from '@/components/sections/hero';
 import About from '@/components/sections/About';
 import ServicesSection from '@/components/sections/ServicesSection';
+import PortfolioSection from '@/components/sections/PortfolioSection';
 import TestimonialsSection from '@/components/sections/TestimonialsSection';
 import FaqSection from '@/components/sections/FaqSection';
 import ContactSection from '@/components/sections/ContactSection';
@@ -16,12 +17,11 @@ function App() {
       <Hero />
       <About />
       <ServicesSection />
+      <PortfolioSection />
       <TestimonialsSection />
       <FaqSection />
       <ContactSection />
-      <div className="mx-auto max-w-7xl px-4">
-        <Footer />
-      </div>
+      <Footer />
     </>
   );
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,14 +3,14 @@ import logo from '../../assets/logo.svg';
 
 const links = [
   { label: 'Home', href: '#' },
-  { label: 'Services', href: '#' },
-  { label: 'About', href: '#' },
-  { label: 'Contact', href: '#' },
+  { label: 'Services', href: '#services' },
+  { label: 'Portfolio', href: '#portfolio' },
+  { label: 'Contact', href: '#contact' },
 ];
 
 const Footer: FC = () => (
-  <footer className="mt-24 bg-gray-100 text-gray-600 dark:bg-[#0f0f0f] dark:text-gray-400">
-    <div className="mx-auto max-w-7xl px-6 py-12">
+  <footer className="fixed bottom-0 left-0 w-full bg-gray-100 text-gray-600 dark:bg-[#0f0f0f] dark:text-gray-400">
+    <div className="mx-auto max-w-7xl px-6 py-8">
       <div className="flex flex-col items-center justify-between gap-8 md:flex-row">
         <div className="flex items-center gap-2">
           <img src={logo} alt="Techno Tech logo" className="h-8" />
@@ -28,9 +28,28 @@ const Footer: FC = () => (
             </li>
           ))}
         </ul>
+        <div className="text-center text-sm md:text-right">
+          <p>
+            <a
+              href="mailto:info@technotech.com"
+              className="transition-colors hover:text-gray-900 dark:hover:text-white"
+            >
+              info@technotech.com
+            </a>
+          </p>
+          <p>
+            <a
+              href="tel:+15551234567"
+              className="transition-colors hover:text-gray-900 dark:hover:text-white"
+            >
+              +1 (555) 123-4567
+            </a>
+          </p>
+          <p>New York, USA</p>
+        </div>
       </div>
       <p className="mt-8 text-center text-sm text-gray-500 dark:text-gray-500">
-        © 2025 Techno Tech Inc. All rights reserved.
+        © 2025 Techno Tech. All rights reserved.
       </p>
     </div>
   </footer>

--- a/src/components/sections/PortfolioSection.tsx
+++ b/src/components/sections/PortfolioSection.tsx
@@ -1,0 +1,79 @@
+import { FC } from 'react';
+import { motion } from 'framer-motion';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+} from '@/components/ui/card';
+import Button from '@/components/ui/Button';
+
+interface Project {
+  title: string;
+  description: string;
+  image: string;
+}
+
+const projects: Project[] = [
+  {
+    title: 'Project Alpha',
+    description: 'An innovative solution for task management.',
+    image: 'https://via.placeholder.com/400x250',
+  },
+  {
+    title: 'Beta Dashboard',
+    description: 'Modern dashboard for tracking metrics and analytics.',
+    image: 'https://via.placeholder.com/400x250',
+  },
+  {
+    title: 'Gamma Platform',
+    description: 'A scalable e-commerce platform built for growth.',
+    image: 'https://via.placeholder.com/400x250',
+  },
+];
+
+const PortfolioSection: FC = () => (
+  <section id="portfolio" className="bg-white py-16 dark:bg-gray-900">
+    <div className="mx-auto mb-12 max-w-5xl px-4 text-center">
+      <h2 className="mb-4 text-3xl font-semibold text-gray-900 dark:text-white">
+        Our Work
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300">
+        A showcase of some of our recent projects.
+      </p>
+    </div>
+    <div className="mx-auto grid max-w-5xl grid-cols-1 gap-8 px-4 md:grid-cols-3">
+      {projects.map((project, index) => (
+        <motion.div
+          key={project.title}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          whileHover={{ y: -5 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, delay: index * 0.1 }}
+        >
+          <Card className="h-full overflow-hidden bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl dark:bg-gray-800">
+            <img
+              src={project.image}
+              alt={project.title}
+              className="h-40 w-full object-cover"
+            />
+            <CardHeader>
+              <CardTitle className="text-gray-900 dark:text-white">
+                {project.title}
+              </CardTitle>
+              <CardDescription>{project.description}</CardDescription>
+            </CardHeader>
+            <CardFooter>
+              <Button>View More</Button>
+            </CardFooter>
+          </Card>
+        </motion.div>
+      ))}
+    </div>
+  </section>
+);
+
+export default PortfolioSection;
+

--- a/src/components/sections/TestimonialsSection.tsx
+++ b/src/components/sections/TestimonialsSection.tsx
@@ -1,26 +1,33 @@
 import { FC } from 'react';
 import { motion } from 'framer-motion';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/components/ui/card';
+import { Star } from 'lucide-react';
 
 const testimonials = [
   {
     name: 'Sarah M.',
     role: 'Business Owner',
-    initial: 'S',
+    avatar: 'https://via.placeholder.com/64',
     text:
       'Techno Tech transformed our operations with their automation solutions. The team was supportive from start to finish and delivered beyond expectations.',
   },
   {
     name: 'John D.',
     role: 'Startup Founder',
-    initial: 'J',
+    avatar: 'https://via.placeholder.com/64',
     text:
       'Working with Techno Tech has been a game changer for our startup. Their expertise helped us streamline processes and focus on growth.',
   },
   {
     name: 'Emily R.',
     role: 'Marketing Lead',
-    initial: 'E',
+    avatar: 'https://via.placeholder.com/64',
     text:
       'The custom tools they built saved us countless hours. Their attention to detail and commitment to quality are unmatched.',
   },
@@ -42,11 +49,18 @@ const TestimonialsSection: FC = () => (
         >
           <Card className="h-full">
             <CardHeader className="flex flex-col items-center text-center">
-              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-red-800 to-amber-500 text-2xl font-bold text-white">
-                {t.initial}
-              </div>
+              <img
+                src={t.avatar}
+                alt={t.name}
+                className="mb-4 h-16 w-16 rounded-full object-cover"
+              />
               <CardTitle>{t.name}</CardTitle>
               <CardDescription>{t.role}</CardDescription>
+              <div className="mt-2 flex gap-1">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Star key={i} className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                ))}
+              </div>
             </CardHeader>
             <CardContent>
               <p className="text-gray-600 dark:text-gray-300">{t.text}</p>


### PR DESCRIPTION
## Summary
- add portfolio showcase section with project cards
- enhance testimonials with avatars and star ratings
- finalize sticky footer with navigation and contact info

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927da7a328832f88b61506db8ab023