### PR TITLE
fix: forward refs in form inputs

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,14 +1,17 @@
-import { FC, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
 
-const Input: FC<InputProps> = ({ className = '', ...props }) => {
-  return (
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className = '', ...props }, ref) => (
     <input
+      ref={ref}
       className={`w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none transition dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 ${className}`}
       {...props}
     />
-  );
-};
+  ),
+);
+
+Input.displayName = 'Input';
 
 export default Input;

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,14 +1,17 @@
-import { FC, TextareaHTMLAttributes } from 'react';
+import { forwardRef, TextareaHTMLAttributes } from 'react';
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
-const Textarea: FC<TextareaProps> = ({ className = '', ...props }) => {
-  return (
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className = '', ...props }, ref) => (
     <textarea
+      ref={ref}
       className={`w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none transition dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 ${className}`}
       {...props}
     />
-  );
-};
+  ),
+);
+
+Textarea.displayName = 'Textarea';
 
 export default Textarea;


### PR DESCRIPTION
## Summary
- forward React refs in Input and Textarea so form libraries can safely attach events

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68928887546c832faa492ca8f94dc044