### PR TITLE
refactor: guard DOM access before mounting app

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,8 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
-// Ensure DOM is ready before accessing elements
-window.addEventListener('DOMContentLoaded', () => {
+// Safely render the app only after the DOM is ready
+const renderApp = () => {
   const rootElement = document.getElementById('root');
   if (rootElement) {
     ReactDOM.createRoot(rootElement).render(
@@ -13,4 +13,10 @@ window.addEventListener('DOMContentLoaded', () => {
       </React.StrictMode>,
     );
   }
-});
+};
+
+if (document.readyState !== 'loading') {
+  renderApp();
+} else {
+  window.addEventListener('DOMContentLoaded', renderApp);
+}


### PR DESCRIPTION
## Summary
- ensure the app only mounts after the DOM is ready and the `#root` element exists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892b59a1828832fa05584b25dc82306