### PR TITLE
fix: safely attach DOM ready listener

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,8 +15,25 @@ const renderApp = () => {
   }
 };
 
+const safeAddEventListener = (
+  e: EventTarget | null,
+  t: string,
+  n: EventListenerOrEventListenerObject,
+  r?: boolean | AddEventListenerOptions,
+) => {
+  if (e) {
+    e.addEventListener(t, n, r);
+    return () => e.removeEventListener(t, n);
+  }
+  return () => {};
+};
+
 if (document.readyState !== 'loading') {
   renderApp();
 } else {
-  window.addEventListener('DOMContentLoaded', renderApp);
+  safeAddEventListener(
+    typeof window !== 'undefined' ? window : null,
+    'DOMContentLoaded',
+    renderApp,
+  );
 }


### PR DESCRIPTION
## Summary
- guard DOMContentLoaded listener with null-safe utility

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892b7c777d8832fbb37178f10f05734