### PR TITLE
fix: guard addEventListener against null

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { safeAddEventListener } from './utils/safeEventListener';
 
 // Safely render the app only after the DOM is ready
 const renderApp = () => {
@@ -13,19 +14,6 @@ const renderApp = () => {
       </React.StrictMode>,
     );
   }
-};
-
-const safeAddEventListener = (
-  e: EventTarget | null,
-  t: string,
-  n: EventListenerOrEventListenerObject,
-  r?: boolean | AddEventListenerOptions,
-) => {
-  if (e) {
-    e.addEventListener(t, n, r);
-    return () => e.removeEventListener(t, n);
-  }
-  return () => {};
 };
 
 if (document.readyState !== 'loading') {

--- a/src/utils/safeEventListener.ts
+++ b/src/utils/safeEventListener.ts
@@ -1,0 +1,12 @@
+export const safeAddEventListener = (
+  e: EventTarget | null,
+  t: string,
+  n: EventListenerOrEventListenerObject,
+  r?: boolean | AddEventListenerOptions,
+) => {
+  if (e) {
+    e.addEventListener(t, n, r);
+    return () => e.removeEventListener(t, n);
+  }
+  return () => {};
+};


### PR DESCRIPTION
## Summary
- extract reusable `safeAddEventListener` utility to guard against null targets
- use helper when attaching `DOMContentLoaded` listener to window

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_6892baa52ac4832f9f2eead47ccf766e