### PR TITLE
fix: guard DOM event listener usage

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,12 +16,14 @@ const renderApp = () => {
   }
 };
 
-if (document.readyState !== 'loading') {
-  renderApp();
-} else {
-  safeAddEventListener(
-    typeof window !== 'undefined' ? window : null,
-    'DOMContentLoaded',
-    renderApp,
-  );
+if (typeof document !== 'undefined') {
+  if (document.readyState !== 'loading') {
+    renderApp();
+  } else {
+    safeAddEventListener(
+      typeof window !== 'undefined' ? window : null,
+      'DOMContentLoaded',
+      renderApp,
+    );
+  }
 }

--- a/src/utils/safeEventListener.ts
+++ b/src/utils/safeEventListener.ts
@@ -4,9 +4,11 @@ export const safeAddEventListener = (
   n: EventListenerOrEventListenerObject,
   r?: boolean | AddEventListenerOptions,
 ) => {
-  if (e) {
+  if (e && 'addEventListener' in e) {
     e.addEventListener(t, n, r);
-    return () => e.removeEventListener(t, n);
+    return () => (e as EventTarget).removeEventListener(t, n, r);
   }
-  return () => {};
+  return () => {
+    /* noop */
+  };
 };


### PR DESCRIPTION
## Summary
- avoid attaching event listeners to missing elements
- only render app when `document` is available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892bf1778e4832fb4e678a5b1a8691c