### PR TITLE
chore: guard event listener usage

### DIFF
--- a/src/utils/safeEventListener.ts
+++ b/src/utils/safeEventListener.ts
@@ -1,14 +1,25 @@
 export const safeAddEventListener = (
-  e: EventTarget | null,
+  e: EventTarget | null | undefined,
   t: string,
   n: EventListenerOrEventListenerObject,
   r?: boolean | AddEventListenerOptions,
 ) => {
-  if (e && 'addEventListener' in e) {
+  if (e && 'addEventListener' in e && 'removeEventListener' in e) {
     e.addEventListener(t, n, r);
     return () => (e as EventTarget).removeEventListener(t, n, r);
   }
   return () => {
     /* noop */
   };
+};
+
+export const safeRemoveEventListener = (
+  e: EventTarget | null | undefined,
+  t: string,
+  n: EventListenerOrEventListenerObject,
+  r?: boolean | EventListenerOptions,
+) => {
+  if (e && 'removeEventListener' in e) {
+    (e as EventTarget).removeEventListener(t, n, r);
+  }
 };


### PR DESCRIPTION
## Summary
- ensure event listener helpers verify targets before using `addEventListener`
- add `safeRemoveEventListener` helper for defensive cleanup

## Testing
- `npm run build`
- `npm run preview` *(fails: Stopped)*

------
https://chatgpt.com/codex/tasks/task_e_6892c361a964832f96d6c8c44be5ea8e