### PR TITLE
fix: guard DOM event listeners

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,10 +20,6 @@ if (typeof document !== 'undefined') {
   if (document.readyState !== 'loading') {
     renderApp();
   } else {
-    safeAddEventListener(
-      typeof window !== 'undefined' ? window : null,
-      'DOMContentLoaded',
-      renderApp,
-    );
+    safeAddEventListener(document, 'DOMContentLoaded', renderApp);
   }
 }

--- a/src/utils/safeEventListener.ts
+++ b/src/utils/safeEventListener.ts
@@ -1,13 +1,14 @@
 export const safeAddEventListener = (
-  e: EventTarget | null,
-  t: string,
-  n: EventListenerOrEventListenerObject,
-  r?: boolean | AddEventListenerOptions,
+  target: EventTarget | null,
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | AddEventListenerOptions,
 ) => {
-  if (e && 'addEventListener' in e) {
-    e.addEventListener(t, n, r);
-    return () => (e as EventTarget).removeEventListener(t, n, r);
+  if (target?.addEventListener) {
+    target.addEventListener(type, listener, options);
+    return () => target.removeEventListener(type, listener, options);
   }
+
   return () => {
     /* noop */
   };


### PR DESCRIPTION
## Summary
- avoid null listeners in safeAddEventListener
- attach DOMContentLoaded handler to `document`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6892ce7680e0832fa9df770b077d1a8f