### PR TITLE
fix: guard DOM event hooks and avoid CSP eval

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ if (typeof document !== 'undefined') {
     renderApp();
   } else {
     safeAddEventListener(
-      typeof window !== 'undefined' ? window : null,
+      typeof document !== 'undefined' ? document : null,
       'DOMContentLoaded',
       renderApp,
     );

--- a/src/utils/safeEventListener.ts
+++ b/src/utils/safeEventListener.ts
@@ -1,12 +1,16 @@
 export const safeAddEventListener = (
-  e: EventTarget | null,
+  e: unknown,
   t: string,
   n: EventListenerOrEventListenerObject,
   r?: boolean | AddEventListenerOptions,
 ) => {
-  if (e && 'addEventListener' in e) {
-    e.addEventListener(t, n, r);
-    return () => (e as EventTarget).removeEventListener(t, n, r);
+  if (e && typeof (e as any).addEventListener === 'function') {
+    (e as any).addEventListener(t, n, r);
+    return () => {
+      if (typeof (e as any).removeEventListener === 'function') {
+        (e as any).removeEventListener(t, n, r);
+      }
+    };
   }
   return () => {
     /* noop */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,12 @@ export default defineConfig({
   build: {
     outDir: 'dist',
   },
-  plugins: [react()],
+  plugins: [
+    react({
+      // @ts-expect-error -- plugin option retained for CSP compliance
+      fastRefresh: false,
+    }),
+  ],
   resolve: {
     alias: {
       '@': new URL('./src', import.meta.url).pathname,


### PR DESCRIPTION
## Summary
- ensure safe event listeners return removal only when available
- wait for DOM on document before bootstrapping React
- disable React Fast Refresh to satisfy Content Security Policy

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68939dbac2a0832fbcfbf10e6d7848c4