### PR TITLE
Guard event listeners against null targets

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,11 +19,7 @@ const renderApp = () => {
 if (typeof document !== 'undefined') {
   if (document.readyState !== 'loading') {
     renderApp();
-  } else {
-    safeAddEventListener(
-      typeof window !== 'undefined' ? window : null,
-      'DOMContentLoaded',
-      renderApp,
-    );
+  } else if (typeof window !== 'undefined') {
+    safeAddEventListener(window, 'DOMContentLoaded', renderApp);
   }
 }

--- a/src/utils/safeEventListener.ts
+++ b/src/utils/safeEventListener.ts
@@ -4,11 +4,12 @@ export const safeAddEventListener = (
   n: EventListenerOrEventListenerObject,
   r?: boolean | AddEventListenerOptions,
 ) => {
-  if (e && 'addEventListener' in e) {
-    e.addEventListener(t, n, r);
-    return () => (e as EventTarget).removeEventListener(t, n, r);
+  if (!e) {
+    return () => {
+      /* noop */
+    };
   }
-  return () => {
-    /* noop */
-  };
+
+  e.addEventListener(t, n, r);
+  return () => e.removeEventListener(t, n, r);
 };


### PR DESCRIPTION
## Summary
- check for null before adding DOM listeners to avoid runtime errors
- skip DOMContentLoaded handler when `window` is undefined

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893a393e2bc832f8776d8256f2400ba